### PR TITLE
CI: Add Travis README badge, use new Ruby versions in build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
-sudo: false
 language: ruby
 rvm:
-  - 1.9.3
-before_install: gem install bundler -v 1.16.0
+  - "2.7"
+  - "2.6"
+  - "2.5"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,19 +8,19 @@ GEM
   specs:
     diff-lcs (1.3)
     rake (13.0.1)
-    rspec (3.7.0)
-      rspec-core (~> 3.7.0)
-      rspec-expectations (~> 3.7.0)
-      rspec-mocks (~> 3.7.0)
-    rspec-core (3.7.1)
-      rspec-support (~> 3.7.0)
-    rspec-expectations (3.7.0)
+    rspec (3.9.0)
+      rspec-core (~> 3.9.0)
+      rspec-expectations (~> 3.9.0)
+      rspec-mocks (~> 3.9.0)
+    rspec-core (3.9.1)
+      rspec-support (~> 3.9.1)
+    rspec-expectations (3.9.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.7.0)
-    rspec-mocks (3.7.0)
+      rspec-support (~> 3.9.0)
+    rspec-mocks (3.9.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.7.0)
-    rspec-support (3.7.1)
+      rspec-support (~> 3.9.0)
+    rspec-support (3.9.2)
 
 PLATFORMS
   ruby
@@ -32,4 +32,4 @@ DEPENDENCIES
   rspec
 
 BUNDLED WITH
-   1.16.0
+   2.1.4

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Bankline CSV import file
 
+[![Build Status](https://secure.travis-ci.org/barsoom/bankline_csv_import_file.svg)](http://travis-ci.org/barsoom/bankline_csv_import_file)
+
 Generate Bankline CSV import files per <https://www.business.rbs.co.uk/content/dam/rbs_co_uk/Business_and_Content/PDFs/Bankline/Bankline-import-file-guide-CSV-RBS.pdf>, used e.g. by NatWest.
 
 Not intended to be a complete implementation. We have implemented what we need; feel free to make PRs for further behaviour.


### PR DESCRIPTION
This PR updates the Travis configuration and prepares a matrix with only in-support Ruby versions. We are green 🟢 on these, and no warnings.

## Travis

 - Ruby versions not-EOL in CI. [See Ruby-lang.org for more information](https://www.ruby-lang.org/en/downloads/branches/)
 - ~After merge, we can activate this repository~ The repository has been activated, and a build has been triggered on this branch, manually.
 - Build status badge

## Gemfile.lock

 - `Gemfile.lock`: Use Bundler 2 (it is allowed in the gemspec). Bundler 2 would be installed with the new Ruby versions.