### PR TITLE
CI: Configure CI not to warn about Bundler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,14 @@
 language: ruby
+
 rvm:
   - "2.7"
   - "2.6"
   - "2.5"
+
 cache: bundler
+
+# 2020-04-24: Avoid deprecation warning about --deployment and --path flags
+install: bundle install --jobs=3 --retry=3
+env:
+  global:
+    - BUNDLE_PATH=vendor/bundle


### PR DESCRIPTION
This PR avoids a Bundler deprecation warning by overwriting some ancient default in Travis' `install` command.

- avoid `--deployment`
- set ENV var `BUNDLE_PATH` instead of using `--path`

Travis documentation on `language: ruby`: https://docs.travis-ci.com/user/languages/ruby/